### PR TITLE
add support laravel 5.4 & 404 errors pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "illuminate/support": "5.3.*"
+        "illuminate/support": "5.3.*||5.4.*"
     }
 }

--- a/src/Generators/FullRoutePath.php
+++ b/src/Generators/FullRoutePath.php
@@ -25,15 +25,20 @@ class FullRoutePath extends GeneratorAbstract
 {
     public function generateClassName()
     {
-        $path = $this->getRoute()->getPath();
+        $route = $this->getRoute();
 
+        if(!$route) // if this route is error page (404..)
+            return 'error-404-page';
+
+        $path = $route->getPath();
+        
         // Return early if no route path exists (such as viewing homepage/index)
         if ('/' === $path) {
             return null;
         }
 
         // Remove route parameters. product_id is removed here: `controller/product/{product_id}`
-        $className = preg_replace("/\{([^}]+)\}/", '', $this->getRoute()->getPath());
+        $className = preg_replace("/\{([^}]+)\}/", '', $path);
 
         // Remove characters that aren't alpha, numeric, or dashes
         $className = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $className);

--- a/src/Generators/FullRoutePath.php
+++ b/src/Generators/FullRoutePath.php
@@ -30,7 +30,7 @@ class FullRoutePath extends GeneratorAbstract
         if(!$route) // if this route is error page (404..)
             return 'error-404-page';
 
-        $path = $route->getPath();
+        $path = $route->uri();
         
         // Return early if no route path exists (such as viewing homepage/index)
         if ('/' === $path) {


### PR DESCRIPTION
- add support laravel 5.4
- sometimes maybe errors pages use the same main layout of the site or same header, so getRoute() will be null on errors pages because route doesn't exist