### PR TITLE
Update str_slug to Str::slug

### DIFF
--- a/src/RouteToClass.php
+++ b/src/RouteToClass.php
@@ -2,6 +2,8 @@
 
 namespace Zschuessler\RouteToClass;
 
+use Illuminate\Support\Str;
+
 /**
  * Class RouteToClass
  *
@@ -125,7 +127,7 @@ class RouteToClass
     /**
      * Sanitize CSS Class String
      *
-     * Currently a simple wrapper around the `str_slug` method in Laravel.
+     * Currently a simple wrapper around the `Str::slug` method in Laravel.
      *
      * @param $value string The class name to sanitize.
      *
@@ -133,7 +135,7 @@ class RouteToClass
      */
     public function sanitizeClassString($value)
     {
-        return str_slug($value);
+        return Str::slug($value);
     }
 
     /**


### PR DESCRIPTION
str_slug was removed in Laravel 6

I checked Str::slug existed in Laravel 5.3, so this does not break backwards compatibility

https://laravel.com/api/5.3/Illuminate/Support/Str.html